### PR TITLE
#2 部分关键字建议

### DIFF
--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -210,13 +210,13 @@ namespace ts {
         "声明": SyntaxKind.DeclareKeyword,
         "默认": SyntaxKind.DefaultKeyword,
         "删除": SyntaxKind.DeleteKeyword,
-        "开始": SyntaxKind.DoKeyword,
+        "运行": SyntaxKind.DoKeyword,
         "否则": SyntaxKind.ElseKeyword,
         "枚举": SyntaxKind.EnumKeyword,
         "导出": SyntaxKind.ExportKeyword,
         "扩展": SyntaxKind.ExtendsKeyword,
 
-        "为假": SyntaxKind.FalseKeyword,
+        "假": SyntaxKind.FalseKeyword,
 
         "最后": SyntaxKind.FinallyKeyword,
         "循环": SyntaxKind.ForKeyword,
@@ -267,7 +267,7 @@ namespace ts {
 
         "抛出": SyntaxKind.ThrowKeyword,
 
-        "为真": SyntaxKind.TrueKeyword,
+        "真": SyntaxKind.TrueKeyword,
 
         "尝试": SyntaxKind.TryKeyword,
         "类型": SyntaxKind.TypeKeyword,
@@ -278,7 +278,7 @@ namespace ts {
         "变量": SyntaxKind.VarKeyword,
         "无值": SyntaxKind.VoidKeyword,
 
-        "判断": SyntaxKind.WhileKeyword,
+        "只要": SyntaxKind.WhileKeyword,
 
         "外扩": SyntaxKind.WithKeyword,
         "获得": SyntaxKind.YieldKeyword,


### PR DESCRIPTION
false/true的原因是:
相比
`变量 我是歌手 = 为假`
感觉还是 
`变量 我是歌手 = 假` 
更合适
暂时没想到两字的用词. 