### PR TITLE
#2 又几个关键词

### DIFF
--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -215,16 +215,16 @@ namespace ts {
 
         "假的": SyntaxKind.FalseKeyword,
 
-        "最后": SyntaxKind.FinallyKeyword,
+        "善后": SyntaxKind.FinallyKeyword,
         "循环": SyntaxKind.ForKeyword,
         "来自": SyntaxKind.FromKeyword,
         "函数": SyntaxKind.FunctionKeyword,
         "获取": SyntaxKind.GetKeyword,
         "如果": SyntaxKind.IfKeyword,
         "实现": SyntaxKind.ImplementsKeyword,
-        "引用": SyntaxKind.ImportKeyword,
+        "导入": SyntaxKind.ImportKeyword,
         "位于": SyntaxKind.InKeyword,
-        "为类": SyntaxKind.InstanceOfKeyword,
+        "身为": SyntaxKind.InstanceOfKeyword,
         "接口": SyntaxKind.InterfaceKeyword,
 
         "是为": SyntaxKind.IsKeyword,


### PR DESCRIPTION
善后 - [这里](http://www.baike.com/wiki/%E5%96%84%E5%90%8E)给出的意思是"处理事务的后续问题，妥善处理事情发生后的遗留问题" 感觉蛮接近Finally的用途
导入 - 感觉Import和Export的作用是对应而且相反的, 那么中文最好也是对应而且相反?
InstanceOf - 如果它也可以用于接口, 比如`某某对象 instanceOf 某某接口`, 那么`为类`好像就有点不全面? 不过`身为`个人感觉有点太拟人化, 但暂时没有想到其他的...